### PR TITLE
Make pdb.orig_set_trace available

### DIFF
--- a/pdb.py
+++ b/pdb.py
@@ -81,6 +81,11 @@ def import_from_stdlib(name):
 
 pdb = import_from_stdlib('pdb')
 
+# Make the original pdb's set_trace available, for e.g.
+# PYTHONBREAKPOINT=pdb.orig_set_trace.
+# It does not handle "pdb.pdb.set_trace" there.
+orig_set_trace = pdb.set_trace
+
 
 def rebind_globals(func, newglobals):
     newfunc = types.FunctionType(func.__code__, newglobals, func.__name__,

--- a/testing/test_pdb.py
+++ b/testing/test_pdb.py
@@ -3928,3 +3928,18 @@ def test_do_source_without_truncating():
 \d\d         pass
 # c
 """)
+
+
+def test_orig_pdb_set_trace():
+    def fn():
+        set_trace()
+
+    check(fn, """
+--Return-
+[NUM] > .*fn()
+-> set_trace()
+   5 frames hidden .*
+# import pdb
+# assert pdb.orig_set_trace is pdb.pdb.set_trace
+# c
+""")


### PR DESCRIPTION
Seems to be necessary for `PYTHONBREAKPOINT`.

```
PYTHONBREAKPOINT=pdb.pdb.set_trace python -c 'breakpoint()'
-c:1: RuntimeWarning: Ignoring unimportable $PYTHONBREAKPOINT: "pdb.pdb.set_trace"
```

I have improved this for pytest's `--pdbcls` to also handle attributes, but am not sure if it is acceptable/worth it for Python itself..
Ref: https://github.com/pytest-dev/pytest/pull/4855

Moved from https://github.com/antocuni/pdb/pull/142.