### PR TITLE
[WIP] Ship a tox plugin to automatically install pdbpp into tox venvs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -347,6 +347,17 @@ default value:
 .. _SGR parameters: https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters
 
 
+Tox plugin
+----------
+
+``pdb++`` ships a plugin for tox_, which installs ``pdbpp`` automatically in
+Tox environments.
+This gets skipped for isolated builds, and can be skipped by setting
+``PDBPP_SKIP_TOX=1`` in the environment.
+
+.. _tox: https://github.com/tox-dev/tox
+
+
 Coding guidelines
 -----------------
 

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     use_scm_version=True,
     author='Antonio Cuni',
     author_email='anto.cuni@gmail.com',
-    py_modules=['pdb', '_pdbpp_path_hack.pdb'],
+    py_modules=['pdb', '_pdbpp_path_hack.pdb', 'tox_pdbpp'],
     url='http://github.com/antocuni/pdb',
     license='BSD',
     platforms=['unix', 'linux', 'osx', 'cygwin', 'win32'],
@@ -94,6 +94,11 @@ setup(
         ],
     },
     setup_requires=['setuptools_scm'],
+    entry_points={
+        'tox': [
+            'pdbpp = tox_pdbpp',
+        ],
+    },
     cmdclass={
         'install': install_with_pth,
         'install_pth_hack': install_pth_hack,

--- a/tox_pdbpp.py
+++ b/tox_pdbpp.py
@@ -1,0 +1,20 @@
+"""
+A tox plugin to automatically install pdbpp with tox.
+
+It gets skipped with isolated builds, e.g. with tox's own tests.
+"""
+import pluggy
+from tox.config import DepConfig
+
+hookimpl = pluggy.HookimplMarker("tox")
+
+
+@hookimpl
+def tox_configure(config):
+    if config.isolated_build:
+        return
+    dep = DepConfig('pdbpp')
+    for envname in config.envlist:
+        envconfig = config.envconfigs[envname]
+        if 'pdbpp' not in (x.name for x in envconfig.deps):
+            envconfig.deps.append(dep)

--- a/tox_pdbpp.py
+++ b/tox_pdbpp.py
@@ -3,6 +3,8 @@ A tox plugin to automatically install pdbpp with tox.
 
 It gets skipped with isolated builds, e.g. with tox's own tests.
 """
+import os
+
 import pluggy
 from tox.config import DepConfig
 
@@ -12,6 +14,8 @@ hookimpl = pluggy.HookimplMarker("tox")
 @hookimpl
 def tox_configure(config):
     if config.isolated_build:
+        return
+    if os.environ.get("PDBPP_SKIP_TOX", "0") == "1":
         return
     dep = DepConfig('pdbpp')
     for envname in config.envlist:


### PR DESCRIPTION
Continuation of https://github.com/antocuni/pdb/pull/98, since I deleted my fork.

TODO:

- [ ] revisit from the plugin used with testmon (https://github.com/tarpas/pytest-testmon/blob/master/testmon/tox_testmon.py), e.g. it should also display info when being used.